### PR TITLE
fix: change homfragment location logic

### DIFF
--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/dao/SqlQuery.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/dao/SqlQuery.kt
@@ -1,0 +1,11 @@
+package com.sandy.seoul_matcheap.data.store.dao
+
+/**
+ * @author SANDY
+ * @email nnal0256@naver.com
+ * @created 2023-08-14
+ * @desc
+ */
+
+const val DEFAULT_DISTANCE = 5
+const val DISTANCE = "ABS(lat - :curLat) + ABS(lng - :curLng) AS distance"

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/repository/StoreRepository.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/repository/StoreRepository.kt
@@ -1,5 +1,7 @@
 package com.sandy.seoul_matcheap.data.store.repository
 
+import android.location.Location
+import android.util.Log
 import com.sandy.seoul_matcheap.data.store.dao.*
 import com.sandy.seoul_matcheap.data.store.entity.StoreInfo
 import com.sandy.seoul_matcheap.util.constants.DEFAULT_
@@ -21,12 +23,14 @@ class StoreRepository @Inject constructor(private val dao: StoreDao) {
 
 
     //!-- select storeList
-    suspend fun downloadSurroundingStores() = dao.getSurroundingStores()
+    suspend fun downloadSurroundingStores(location: Location) = dao.getSurroundingStores(
+        location.latitude, location.longitude
+    )
 
     suspend fun downloadRandomStores() = dao.getRandomStores()
 
-    fun downloadStoreList(gu: String? = null) = dao.run {
-        if(gu == null) getStoreList()
+    fun downloadStoreList(location: Location, gu: String? = null) = dao.run {
+        if(gu == null) getStoreList(location.latitude, location.longitude)
         else getStoreList(gu)
     }
 

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/LocationViewModel.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/LocationViewModel.kt
@@ -21,7 +21,7 @@ import javax.inject.Inject
  * @author SANDY
  * @email nnal0256@naver.com
  * @created 2021-10-17
- * @desc
+ * @desc location viewModel should be called from activityViewModels() (sharedViewModel)
  */
 
 @HiltViewModel
@@ -32,6 +32,7 @@ class LocationViewModel @Inject constructor(
 
     private val _location = MutableLiveData<Location?>()
     val location: LiveData<Location?> = _location
+    fun getCurLocation() = location.value
 
     private val locationCallback = object : LocationCallback() {
         override fun onLocationResult(result: LocationResult) {

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/common/BindingAdapter.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/common/BindingAdapter.kt
@@ -1,6 +1,7 @@
 package com.sandy.seoul_matcheap.ui.common
 
 import android.graphics.Typeface
+import android.location.Location
 import android.text.Spannable
 import android.text.Spanned
 import android.text.style.ForegroundColorSpan
@@ -55,6 +56,14 @@ object BindingAdapter {
         distance?.let {
             textView.text = String.format("%.1f km", distance)
             textView.background = null
+        }
+    }
+
+    @JvmStatic
+    @BindingAdapter(value = ["lat", "lng", "curLat", "curLng"])
+    fun inputDistance(textView: TextView, lat: Double?, lng: Double?, curLat: Double?, curLng: Double?) {
+        if(lat != null && lng != null && curLat != null && curLng != null) {
+            textView.text = DataHelper.convertDistance(lat, lng, curLat, curLng)
         }
     }
 

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/home/HomeFragment.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/home/HomeFragment.kt
@@ -8,10 +8,12 @@ import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.fragment.app.activityViewModels
 import com.sandy.seoul_matcheap.BuildConfig
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.RecyclerView
 import com.sandy.seoul_matcheap.R
+import com.sandy.seoul_matcheap.data.store.dao.SurroundingStore
 import com.sandy.seoul_matcheap.databinding.FragmentHomeBinding
 import com.sandy.seoul_matcheap.ui.common.BaseFragment
 import com.sandy.seoul_matcheap.ui.LocationViewModel
@@ -26,7 +28,7 @@ import javax.inject.Named
 @AndroidEntryPoint
 class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
 
-    private val locationViewModel: LocationViewModel by viewModels()
+    private val locationViewModel: LocationViewModel by activityViewModels()
     private val homeViewModel : HomeViewModel by viewModels()
 
     override fun setupBinding(): FragmentHomeBinding = binding.apply {
@@ -36,26 +38,15 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
         viewModel = homeViewModel
     }
 
-    @Inject lateinit var locationManager: LocationManager
-    private var isLoaded = false
-    override fun downloadData() {
-        if(homeViewModel.getCurLoadingState() != ConnectState.NONE) return
-        updateLocation(locationViewModel, locationManager)
-        with(homeViewModel) {
-            updateSurroundingStoreList()
-            updateRandomStoreList()
-        }
-        isLoaded = true
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        checkVersionUpdate(BuildConfig.VERSION_NAME)
+        checkVersionUpdate()
         super.onViewCreated(view, savedInstanceState)
     }
 
     @Inject @Named(APP_PREFS_SETTINGS)
     lateinit var prefs: SharedPreferences
-    private fun checkVersionUpdate(currentVersion: String) {
+    private fun checkVersionUpdate() {
+        val currentVersion = BuildConfig.VERSION_NAME
         when(AppPrefsUtils.getSavedVersion(prefs)) {
             currentVersion -> return
             null -> AppPrefsUtils.saveCurrentVersion(prefs, currentVersion)
@@ -76,6 +67,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
             addOnItemClickListener()
         }
     }
+
     override fun RecyclerView.Adapter<out RecyclerView.ViewHolder>.addOnItemClickListener() {
         when(this) {
             is RegionSpinnerAdapter -> setOnItemClickListener{
@@ -88,7 +80,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     }
 
     override fun initView() = binding.run {
-        setSavedBackstackState()
+        checkSavedBackstackState()
 
         rvRegionSpinner.addAdapter(regionSpinnerAdapter)
         regionSpinnerView.setOnRegionSpinnerViewClickListener()
@@ -102,7 +94,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     }
 
     private var onBackstackCallback = false
-    private fun setSavedBackstackState() = binding.apply {
+    private fun checkSavedBackstackState() = binding.apply {
         if(!onBackstackCallback) {
             nestedScrollView.post {
                 nestedScrollView.scrollY = DEFAULT_POSITION
@@ -123,16 +115,14 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
         rvRegionSpinner.y = SPINNER_DEFAULT_POSION_Y
     }
 
-    // RegionButton을 클릭 했을 때, region spinner가 나타나야하며, 이 때 region spinner는 반드시 위치가 설정된 후 화면에 보여져야함
-    private fun View.setOnRegionButtonClickListener() {
-        setOnClickListener {
-            changeRegionSpinnerRecyclerViewPositionY()
-            showRegionSpinnerView()
-        }
+    // RegionButton을 클릭 했을 때, region spinner가 나타나야하며 이 때 region spinner는 반드시 위치가 설정된 후 화면에 보여져야함
+    private fun View.setOnRegionButtonClickListener() = setOnClickListener {
+        setRegionSpinnerPositionY()
+        showRegionSpinnerView()
     }
 
     private var SPINNER_DEFAULT_POSION_Y: Float = 0.0f
-    private fun changeRegionSpinnerRecyclerViewPositionY() = binding.rvRegionSpinner.apply {
+    private fun setRegionSpinnerPositionY() = binding.rvRegionSpinner.apply {
         // spinner의 default positionY를 측정하여 저장
         SPINNER_DEFAULT_POSION_Y = y
         y = SPINNER_DEFAULT_POSION_Y - binding.nestedScrollView.scrollY
@@ -145,6 +135,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
         rvRegionSpinner.scrollToPosition(DEFAULT_POSITION)
     }
 
+    @Inject lateinit var locationManager: LocationManager
     private var gpsButtonClick = false
     private fun ImageView.setOnGpsUpdateButtonClickListener() = setOnClickListener {
         gpsButtonClick = true
@@ -164,7 +155,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     override fun subscribeToObservers() {
         subscribeToLoadStateObserver()
         subscribeToLocationObserver()
-        subscribeToStoreDataObserver()
+        subscribeToSurroundingStoresObserver()
     }
 
     private fun subscribeToLoadStateObserver() {
@@ -172,6 +163,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
             handleLoadingState(it)
         }
     }
+
     private fun handleLoadingState(state: ConnectState) = when(state) {
         ConnectState.SUCCESS -> handleLoadSuccess()
         ConnectState.FAIL -> handleLoadFail()
@@ -184,10 +176,10 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
         showNetworkErrorToastMessage()
         binding.progressView.fail.visibility = View.VISIBLE
     }
-    private fun showNetworkErrorToastMessage() = if(isLoaded) {
+
+    private var isLoaded = false
+    private fun showNetworkErrorToastMessage() {
         showToastMessage(MESSAGE_NETWORK_ERROR)
-    } else {
-        isLoaded = true
     }
 
     private fun handleNotLoad() {
@@ -199,14 +191,29 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
 
     private fun subscribeToLocationObserver() = locationViewModel.run {
         location.observe(viewLifecycleOwner) {
-            updateForecast(it)
+            handleLocationInfo(it)
         }
         address.observe(viewLifecycleOwner) {
             handleAddress(it)
         }
     }
-    private fun updateForecast(location: Location?) = location?.let {
-        homeViewModel.updateForecast(it.latitude, it.longitude)
+
+    private fun handleLocationInfo(location: Location?) = location?.let {
+        with(homeViewModel) {
+            updateRandomStoreList()
+            updateForecast(it)
+            updateSurroundingStoreList(it)
+        }
+    }
+
+    private fun subscribeToSurroundingStoresObserver() {
+        homeViewModel.surroundingStores.observe(viewLifecycleOwner) {
+            handleSurroundStores(it)
+        }
+    }
+
+    private fun handleSurroundStores(stores: List<SurroundingStore>) {
+        surroundingStoreAdapter?.submitList(stores)
     }
 
     // 현재 주소를 알려주는 toast message는 반드시 gps update button가 호출 되었을 때만 생성 되어야 함
@@ -216,14 +223,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
         gpsButtonClick = false
     }
 
-    private fun subscribeToStoreDataObserver(){
-        homeViewModel.surroundingStores.observe(viewLifecycleOwner) {
-            surroundingStoreAdapter?.run { submitList(it) }
-        }
-    }
-
     fun navigateToStoreListForCategory(v: View, code: String) {
-
         v.changeScale()
         navigateToStoreList(code, TYPE_CATEGORY)
     }

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/home/HomeViewModel.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.sandy.seoul_matcheap.ui.home
 
+import android.location.Location
 import androidx.lifecycle.*
 import com.sandy.seoul_matcheap.data.forecast.Forecast
 import com.sandy.seoul_matcheap.data.forecast.ForecastRepository
@@ -11,6 +12,7 @@ import com.sandy.seoul_matcheap.util.constants.DEFAULT_
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
 import javax.inject.Inject
+import kotlin.math.ln
 
 /**
  * @author SANDY
@@ -25,14 +27,15 @@ class HomeViewModel @Inject constructor (
     private val forecastRepository: ForecastRepository
 ) : ViewModel() {
 
-    //!-- store
+    //!-- surrounding stores
     private val _surroundingStores = MutableLiveData<List<SurroundingStore>>()
     val surroundingStores: LiveData<List<SurroundingStore>> = _surroundingStores
-    fun updateSurroundingStoreList() = viewModelScope.launch(Dispatchers.IO) {
-        val stores = storeRepository.downloadSurroundingStores()
+    fun updateSurroundingStoreList(location: Location) = viewModelScope.launch(Dispatchers.IO) {
+        val stores = storeRepository.downloadSurroundingStores(location)
         _surroundingStores.postValue(stores)
     }
 
+    //!-- random stores
     private val _randomStore = MutableLiveData<List<RandomStore>>()
     val randomStore: LiveData<List<RandomStore>> = _randomStore
     fun updateRandomStoreList() = viewModelScope.launch(Dispatchers.IO) {
@@ -40,12 +43,12 @@ class HomeViewModel @Inject constructor (
         _randomStore.postValue(stores)
     }
 
+
     private val _loadingState = MutableLiveData(ConnectState.NONE)
     val loadingState : LiveData<ConnectState> = _loadingState
     fun setLoadingState(state: ConnectState) {
         _loadingState.postValue(state)
     }
-    fun getCurLoadingState() = _loadingState.value!!
 
 
     //!-- forecast
@@ -57,8 +60,8 @@ class HomeViewModel @Inject constructor (
     val sky : LiveData<String> = _sky
     private val _wind = MutableLiveData<String>()
     val wind : LiveData<String> = _wind
-    fun updateForecast(lat: Double, lng: Double) = viewModelScope.launch(Dispatchers.IO) {
-        val result = forecastRepository.downloadCurrentForecast(lat, lng)
+    fun updateForecast(location: Location) = viewModelScope.launch(Dispatchers.IO) {
+        val result = forecastRepository.downloadCurrentForecast(location.latitude, location.longitude)
         updateWeather(result)
     }
 

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/home/SurroundingStoreAdapter.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/home/SurroundingStoreAdapter.kt
@@ -13,7 +13,7 @@ import com.sandy.seoul_matcheap.util.constants.DEFAULT_POSITION
  * @created 2023-04-07
  * @desc
  */
-class SurroundingStoreAdapter : BaseListAdapter<ItemRvSurroundingBinding, SurroundingStore>(R.layout.item_rv_surrounding) {
+class SurroundingStoreAdapter() : BaseListAdapter<ItemRvSurroundingBinding, SurroundingStore>(R.layout.item_rv_surrounding) {
 
     override fun ItemRvSurroundingBinding.setBinding(item: SurroundingStore, position: Int) {
         store = item

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/splash/LoadViewModel.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/splash/LoadViewModel.kt
@@ -61,12 +61,7 @@ class LoadViewModel @Inject constructor(
             val token = it.split("\t")
             val lat = token[13].trim().toDouble()
             val lng = token[14].trim().toDouble()
-            val distance = DataHelper.calculateDistance(
-                curLat = location.latitude,
-                curLng = location.longitude,
-                lat = lat,
-                lng = lng
-            )
+            val distance = 0.0
             StoreInfo(
                 id = "0000" + token[0].trim(),
                 code = token[1].trim(),

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/util/helper/DataHelper.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/util/helper/DataHelper.kt
@@ -1,6 +1,7 @@
 package com.sandy.seoul_matcheap.util.helper
 
 import android.content.Context
+import android.location.Location
 import java.text.SimpleDateFormat
 import java.time.Duration
 import java.time.LocalDate
@@ -29,8 +30,7 @@ object DataHelper {
         .bufferedReader()
         .readLines()
 
-    private val r = 6372.8 * 1000
-    fun calculateDistance(curLat: Double, curLng: Double, lat: Double, lng : Double) : Double {
+    fun convertDistance(lat: Double, lng : Double, curLat: Double, curLng: Double) : String {
         val a = 2 * asin(
             sqrt(
                 sin(Math.toRadians(lat - curLat) / 2).pow(2.0)
@@ -39,7 +39,7 @@ object DataHelper {
                         * cos(Math.toRadians(lat))
             )
         )
-        return r * a / 1000
+        return String.format("%.1f km", 6372.8 * a)
     }
 
     private val timeFormat = SimpleDateFormat("yyyyMMdd-HHmm")

--- a/Matcheap/app/src/main/res/layout/fragment_home.xml
+++ b/Matcheap/app/src/main/res/layout/fragment_home.xml
@@ -275,9 +275,10 @@
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toBottomOf="@+id/textView53"
-                            bind:fragment="@{fragment}"
                             bind:store1="@{viewModel.randomStore[0]}"
-                            bind:store2="@{viewModel.randomStore[1]}" />
+                            bind:store2="@{viewModel.randomStore[1]}"
+                            bind:fragment="@{fragment}"
+                            bind:location="@{location.location}"/>
 
                     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/Matcheap/app/src/main/res/layout/item_home_random.xml
+++ b/Matcheap/app/src/main/res/layout/item_home_random.xml
@@ -13,6 +13,9 @@
         <variable
             name="fragment"
             type="com.sandy.seoul_matcheap.ui.home.HomeFragment" />
+        <variable
+            name="location"
+            type="android.location.Location" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -46,7 +49,6 @@
 
             <TextView
                 android:id="@+id/textView37"
-                Distance="@{store1.distance}"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="bottom|end"
@@ -58,7 +60,11 @@
                 android:shadowDx="1"
                 android:shadowDy="1"
                 android:shadowRadius="5"
-                android:textSize="10sp" />
+                android:textSize="10sp"
+                app:lat="@{store1.lat}"
+                app:lng="@{store1.lng}"
+                app:curLat="@{location.latitude}"
+                app:curLng="@{location.longitude}" />
         </androidx.cardview.widget.CardView>
 
         <androidx.cardview.widget.CardView
@@ -176,7 +182,6 @@
 
             <TextView
                 android:id="@+id/textView67"
-                Distance="@{store2.distance}"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="bottom|end"
@@ -188,7 +193,11 @@
                 android:shadowDx="1"
                 android:shadowDy="1"
                 android:shadowRadius="5"
-                android:textSize="10sp" />
+                android:textSize="10sp"
+                app:lat="@{store1.lat}"
+                app:lng="@{store1.lng}"
+                app:curLat="@{location.latitude}"
+                app:curLng="@{location.longitude}" />
         </androidx.cardview.widget.CardView>
 
         <androidx.cardview.widget.CardView

--- a/Matcheap/app/src/main/res/layout/item_rv_surrounding.xml
+++ b/Matcheap/app/src/main/res/layout/item_rv_surrounding.xml
@@ -102,7 +102,6 @@
 
                 <TextView
                     android:id="@+id/distance"
-                    Distance="@{store.distance}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="start|top"
@@ -120,6 +119,10 @@
                     android:textStyle="bold"
                     app:layout_constraintStart_toStartOf="@+id/photo"
                     app:layout_constraintTop_toTopOf="@+id/photo"
+                    app:lat="@{store.lat}"
+                    app:lng="@{store.lng}"
+                    app:curLat="@{store.curLat}"
+                    app:curLng="@{store.curLng}"
                     tools:text="1.2 km" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
1. homefragment store 데이터를 불러 올 때 현재 최신 위치를 기반으로 거리를 계산해서 불러오도록 개선 1) StoreDao에서 surroundingStore, randomStore 데이터 가져오는 로직 변경 2) 바인딩어댑터에 inputDistance함수 추가 -> DataHelper에서 거리를 계산하는 함수의 기능을 거리 String Format형식으로 변환하는 함수로 기능 변경

2. homefragment location logic 변경 -> 동일한 함수의 중복된 호출 횟수를 개선하기 위해 location viewModel을 activityViewModels() factory에서 delegation하도록 개선 -> location logic 변경에 따라 영향받는 ui 코드 수정