### PR TITLE
Feature/change distance logic

### DIFF
--- a/Matcheap/app/.gitignore
+++ b/Matcheap/app/.gitignore
@@ -2,3 +2,4 @@
 /src/androidTest
 /src/test
 /src/main/res/raw
+/schemas

--- a/Matcheap/app/build.gradle
+++ b/Matcheap/app/build.gradle
@@ -19,6 +19,12 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
+        kapt {
+            arguments {
+                arg("room.schemaLocation", "$projectDir/schemas")
+            }
+        }
+
     }
 
     buildTypes {

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/StoreDatabase.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/StoreDatabase.kt
@@ -1,7 +1,10 @@
 package com.sandy.seoul_matcheap.data.store
 
+import androidx.room.AutoMigration
 import androidx.room.Database
+import androidx.room.DeleteColumn
 import androidx.room.RoomDatabase
+import androidx.room.migration.AutoMigrationSpec
 import com.sandy.seoul_matcheap.data.store.dao.*
 import com.sandy.seoul_matcheap.data.store.entity.*
 
@@ -14,7 +17,15 @@ import com.sandy.seoul_matcheap.data.store.entity.*
 
 @Database(
     entities = [StoreInfo::class, SearchHistory::class, Bookmark::class, Polygon::class, Menu::class],
-    version = 1
+    version = 2,
+    autoMigrations = [
+        AutoMigration (
+            from = 1,
+            to = 2,
+            spec = StoreDatabase.MyAutoMigration::class
+        )
+    ],
+    exportSchema = true
 )
 abstract class StoreDatabase : RoomDatabase() {
 
@@ -22,5 +33,9 @@ abstract class StoreDatabase : RoomDatabase() {
     abstract fun mapDao() : MapDao
     abstract fun searchDao() : SearchDao
     abstract fun bookmarkDao() : BookmarkDao
+
+    @DeleteColumn(tableName ="store_info", columnName ="codeName")
+    @DeleteColumn(tableName ="store_info", columnName ="distance")
+    class MyAutoMigration : AutoMigrationSpec
 
 }

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/dao/SearchDao.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/dao/SearchDao.kt
@@ -16,12 +16,13 @@ interface SearchDao {
 
     // !-- request search
     @Query(
-        "SELECT id, code, codeName, name, address, photo, distance " +
+        "SELECT id, code, name, address, photo, lat, lng, $CURRENT_LOCATION_QUERY, $DISTANCE_QUERY " +
                 "FROM store_info " +
                 "WHERE REPLACE(name, ' ', '') " +
-                "LIKE '%' || :word || '%'"
+                "LIKE '%' || :param || '%' " +
+                "ORDER BY d"
     )
-    fun requestSearchStore(word: String): PagingSource<Int, StoreListItem>
+    fun requestSearchStore(param: String, curLat:Double, curLng:Double) : PagingSource<Int, StoreItem>
 
 
     // !-- autoComplete

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/dao/SqlQuery.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/dao/SqlQuery.kt
@@ -1,0 +1,12 @@
+package com.sandy.seoul_matcheap.data.store.dao
+
+/**
+ * @author SANDY
+ * @email nnal0256@naver.com
+ * @created 2023-08-14
+ * @desc
+ */
+
+const val DEFAULT_DISTANCE = 5
+const val CURRENT_LOCATION_QUERY =":curLat AS curLat, :curLng AS curLng"
+const val DISTANCE_QUERY = "ABS(lat - :curLat) + ABS(lng - :curLng) AS distance"

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/dao/SqlQuery.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/dao/SqlQuery.kt
@@ -7,6 +7,11 @@ package com.sandy.seoul_matcheap.data.store.dao
  * @desc
  */
 
-const val DEFAULT_DISTANCE = 5
 const val CURRENT_LOCATION_QUERY =":curLat AS curLat, :curLng AS curLng"
-const val DISTANCE_QUERY = "ABS(lat - :curLat) + ABS(lng - :curLng) AS distance"
+const val DISTANCE_QUERY = "(lat - :curLat)*(lat - :curLat) + (lng - :curLng)*(lng - :curLng) AS d"
+
+sealed class DistanceRadius(val value: Double) {
+    object M500 : DistanceRadius(0.005 * 0.005)
+    object M1000 : DistanceRadius(0.01 * 0.01)
+    object M3000 : DistanceRadius(0.03 * 0.03)
+}

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/dao/StoreDao.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/dao/StoreDao.kt
@@ -37,7 +37,7 @@ interface StoreDao {
     suspend fun getSurroundingStores(curLat: Double, curLng: Double): List<StoreItem>
 
     @Query(
-        "SELECT id, code, codeName, name, address, content, photo, lat, lng " +
+        "SELECT id, code, name, address, content, photo, lat, lng " +
                 "FROM store_info " +
                 "WHERE photo != 'http://tearstop.seoul.go.kr/mulga/photo/' " +
                 "ORDER BY RANDOM() " +
@@ -108,9 +108,9 @@ interface StoreDao {
     suspend fun getStoreCountByGuAndCode(gu: String, code: String) : Int
 
     @Query(
-        "SELECT codeName, count(*) " +
+        "SELECT code, count(*) " +
                 "FROM store_info " +
-                "GROUP BY codeName " +
+                "GROUP BY code " +
                 "ORDER BY code "
     )
     suspend fun getStoreTotalCountForCode() : List<StoreTotalCount>
@@ -152,7 +152,6 @@ data class StoreItem(
 data class RandomStore(
     val id: String,
     val code: String,
-    val codeName: String,
     val	name: String,
     val	address: String,
     val content: String,
@@ -169,6 +168,6 @@ data class Count(
 )
 
 data class StoreTotalCount(
-    @ColumnInfo(name = "codeName") val category: String,
+    @ColumnInfo(name = "code") val category: String,
     @ColumnInfo(name = "count(*)") val count: Int
 )

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/dao/StoreDao.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/dao/StoreDao.kt
@@ -29,9 +29,9 @@ interface StoreDao {
 
     //!-- select store list
     @Query(
-        "SELECT id, code, name, address, photo, lat, lng, $DISTANCE_QUERY, $CURRENT_LOCATION_QUERY " +
+        "SELECT id, code, name, address, photo, lat, lng, $CURRENT_LOCATION_QUERY, $DISTANCE_QUERY " +
                 "FROM store_info " +
-                "ORDER BY distance " +
+                "ORDER BY d " +
                 "LIMIT 5"
     )
     suspend fun getSurroundingStores(curLat: Double, curLng: Double): List<StoreItem>
@@ -46,20 +46,24 @@ interface StoreDao {
     suspend fun getRandomStores() : List<RandomStore>
 
     @Query(
-        "SELECT id, code, codeName, name, address, photo, lat, lng, $DISTANCE_QUERY " +
+        "SELECT id, code, name, address, photo, lat, lng, $CURRENT_LOCATION_QUERY, $DISTANCE_QUERY " +
                 "FROM store_info " +
-                "WHERE distance <= 25 " +
-                "ORDER BY distance "
+                "WHERE d <= :r " +
+                "ORDER BY d "
     )
-    fun getStoreListByCategory(curLat: Double, curLng: Double) : PagingSource<Int, StoreItem>
+    fun getStoreListByCategory(
+        curLat: Double,
+        curLng: Double,
+        r: Double
+    ) : PagingSource<Int, StoreItem>
 
     @Query(
-        "SELECT id, code, codeName, name, address, photo, $DISTANCE_QUERY " +
+        "SELECT id, code, name, address, photo, lat, lng, $CURRENT_LOCATION_QUERY, $DISTANCE_QUERY " +
                 "FROM store_info " +
                 "WHERE gu = :gu " +
-                "ORDER BY distance "
+                "ORDER BY d "
     )
-    fun getStoreListByRegion(gu: String) : PagingSource<Int, StoreItem>
+    fun getStoreListByRegion(curLat: Double, curLng: Double, gu: String) : PagingSource<Int, StoreItem>
 
 
     //!-- select recommend store
@@ -74,19 +78,19 @@ interface StoreDao {
 
     // !-- select storeCount
     @Query(
-        "SELECT count(*) " +
+        "SELECT count(*), lat, lng, $DISTANCE_QUERY " +
                 "FROM store_info " +
-                "WHERE distance <= :distance "
+                "WHERE d <= :r "
     )
-    suspend fun getStoreCountByDistance(distance: Int = DEFAULT_DISTANCE) : Int
+    suspend fun getStoreCountByDistance(curLat: Double, curLng: Double, r: Double) : Count
 
     @Query(
-        "SELECT count(*) " +
+        "SELECT count(*), lat, lng, $DISTANCE_QUERY " +
                 "FROM store_info " +
-                "WHERE distance <= :distance " +
-                "AND code = :code "
+                "WHERE d <= :r " +
+                "AND code = :code"
     )
-    suspend fun getStoreCountByDistanceAndCode(code: String, distance: Int = DEFAULT_DISTANCE) : Int
+    suspend fun getStoreCountByDistanceAndCode(curLat: Double, curLng: Double, r: Double, code: String) : Count
 
     @Query(
         "SELECT count(*) " +
@@ -142,7 +146,7 @@ data class StoreItem(
     val lng: Double,
     val curLat: Double,
     val curLng: Double,
-    val distance: Float
+    val d: Float
 ) : Serializable
 
 data class RandomStore(
@@ -155,6 +159,13 @@ data class RandomStore(
     val	photo: String,
     val lat: Double,
     val lng: Double
+)
+
+data class Count(
+    @ColumnInfo(name = "count(*)") val count: Int,
+    val lat: Double,
+    val lng: Double,
+    val d: Float
 )
 
 data class StoreTotalCount(

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/entity/StoreInfo.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/entity/StoreInfo.kt
@@ -14,7 +14,6 @@ data class StoreInfo(
     @PrimaryKey
     val id: String,
     val code: String,
-    val codeName: String,
     val	name: String,
     val gu: String,
     val	address: String,
@@ -26,6 +25,5 @@ data class StoreInfo(
     val content: String,
     val	photo: String,
     val	lat: Double,
-    val	lng: Double,
-    val distance: Double = 0.0
+    val	lng: Double
 )

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/repository/SearchRepository.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/repository/SearchRepository.kt
@@ -1,5 +1,6 @@
 package com.sandy.seoul_matcheap.data.store.repository
 
+import android.location.Location
 import androidx.room.Transaction
 import com.sandy.seoul_matcheap.data.store.dao.SearchDao
 import com.sandy.seoul_matcheap.data.store.entity.SearchHistory
@@ -17,9 +18,9 @@ class SearchRepository @Inject constructor(private val dao: SearchDao) {
 
     // !-- get search result
     @Transaction
-    suspend fun requestSearchStore(param: String) = dao.run {
+    suspend fun requestSearchStore(param: String, curLat:Double, curLng:Double) = dao.run {
         insertSearchHistory(SearchHistory(param.trim(), "${LocalDateTime.now()}"))
-        requestSearchStore(DataHelper.removeSpace(param))
+        requestSearchStore(DataHelper.removeSpace(param), curLat, curLng)
     }
 
 

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/repository/StoreRepository.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/repository/StoreRepository.kt
@@ -1,7 +1,6 @@
 package com.sandy.seoul_matcheap.data.store.repository
 
 import android.location.Location
-import android.util.Log
 import com.sandy.seoul_matcheap.data.store.dao.*
 import com.sandy.seoul_matcheap.data.store.entity.StoreInfo
 import com.sandy.seoul_matcheap.util.constants.DEFAULT_
@@ -29,24 +28,19 @@ class StoreRepository @Inject constructor(private val dao: StoreDao) {
 
     suspend fun downloadRandomStores() = dao.getRandomStores()
 
-    fun downloadStoreList(location: Location, gu: String? = null) = dao.run {
-        if(gu == null) getStoreList(location.latitude, location.longitude)
-        else getStoreList(gu)
-    }
+    fun downloadStoreList(curLat: Double, curLng: Double, gu: String) = dao.getStoreListByRegion(curLat, curLng, gu)
+    fun downloadStoreList(curLat: Double, curLng: Double, r: Double) = dao.getStoreListByCategory(curLat, curLng, r)
 
 
     // !-- select storeCount
-    suspend fun downloadStoreCount(code: String, gu: String? = null) = dao.run {
-        when(code) {
-            DEFAULT_ -> {
-                if(gu == null) getStoreCountByDistance()
-                else getStoreCountByGu(gu)
-            }
-            else -> {
-                if(gu == null) getStoreCountByDistanceAndCode(code)
-                else getStoreCountByGuAndCode(gu, code)
-            }
-        }
+    suspend fun downloadStoreCount(code: String, curLat: Double, curLng: Double, r: Double) = when(code) {
+        DEFAULT_ -> dao.getStoreCountByDistance(curLat, curLng, r)
+        else -> dao.getStoreCountByDistanceAndCode(curLat, curLng, r, code)
+    }
+
+    suspend fun downloadStoreCount(gu: String, code: String) = when(code) {
+        DEFAULT_ -> dao.getStoreCountByGu(gu)
+        else -> dao.getStoreCountByGuAndCode(gu, code)
     }
 
     suspend fun downloadStoreTotalCountForCode() = dao.getStoreTotalCountForCode()

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/repository/StoreRepository.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/data/store/repository/StoreRepository.kt
@@ -1,5 +1,7 @@
 package com.sandy.seoul_matcheap.data.store.repository
 
+import android.location.Location
+import android.util.Log
 import com.sandy.seoul_matcheap.data.store.dao.*
 import com.sandy.seoul_matcheap.data.store.entity.StoreInfo
 import com.sandy.seoul_matcheap.util.constants.DEFAULT_
@@ -21,12 +23,14 @@ class StoreRepository @Inject constructor(private val dao: StoreDao) {
 
 
     //!-- select storeList
-    suspend fun downloadSurroundingStores() = dao.getSurroundingStores()
+    suspend fun downloadSurroundingStores(location: Location) = dao.getSurroundingStores(
+        location.latitude, location.longitude
+    )
 
     suspend fun downloadRandomStores() = dao.getRandomStores()
 
-    fun downloadStoreList(gu: String? = null) = dao.run {
-        if(gu == null) getStoreList()
+    fun downloadStoreList(location: Location, gu: String? = null) = dao.run {
+        if(gu == null) getStoreList(location.latitude, location.longitude)
         else getStoreList(gu)
     }
 

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/LocationViewModel.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/LocationViewModel.kt
@@ -21,7 +21,7 @@ import javax.inject.Inject
  * @author SANDY
  * @email nnal0256@naver.com
  * @created 2021-10-17
- * @desc
+ * @desc location viewModel should be called from activityViewModels() (sharedViewModel)
  */
 
 @HiltViewModel
@@ -30,8 +30,11 @@ class LocationViewModel @Inject constructor(
     private val geocoder: Geocoder
     ) : ViewModel() {
 
-    private val _location = MutableLiveData<Location?>()
-    val location: LiveData<Location?> = _location
+    private val _location = MutableLiveData<Location>()
+    val location: LiveData<Location> = _location
+
+    // Because location information must have been updated on Splash Screen, location should be not null.
+    fun getCurLocation() = location.value!!
 
     private val locationCallback = object : LocationCallback() {
         override fun onLocationResult(result: LocationResult) {
@@ -105,10 +108,6 @@ class LocationViewModel @Inject constructor(
     private fun getAddress(address: List<Address>) : String {
         val split = address.first().getAddressLine(0).split(" ")
         return "${split[1]} ${split[2]} ${split[3]}"
-    }
-
-    fun init() {
-        _location.value = null
     }
 
     companion object {

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/common/BindingAdapter.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/common/BindingAdapter.kt
@@ -1,7 +1,6 @@
 package com.sandy.seoul_matcheap.ui.common
 
 import android.graphics.Typeface
-import android.location.Location
 import android.text.Spannable
 import android.text.Spanned
 import android.text.style.ForegroundColorSpan
@@ -16,6 +15,7 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.sandy.seoul_matcheap.R
 import com.sandy.seoul_matcheap.ui.more.settings.Time
 import com.sandy.seoul_matcheap.util.*
+import com.sandy.seoul_matcheap.util.constants.Category
 import com.sandy.seoul_matcheap.util.constants.DEFAULT_
 import com.sandy.seoul_matcheap.util.helper.DataHelper
 import java.util.*
@@ -72,6 +72,14 @@ object BindingAdapter {
     fun setDateTextview(textView: TextView, now: Boolean?) {
         now?.let {
             textView.text = DataHelper.getDate()
+        }
+    }
+
+    @JvmStatic
+    @BindingAdapter("Code")
+    fun convertCodeName(textView: TextView, code: String?) {
+        code?.let {
+            textView.text = Category.from(it).codeName
         }
     }
 

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/common/BindingAdapter.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/common/BindingAdapter.kt
@@ -1,6 +1,7 @@
 package com.sandy.seoul_matcheap.ui.common
 
 import android.graphics.Typeface
+import android.location.Location
 import android.text.Spannable
 import android.text.Spanned
 import android.text.style.ForegroundColorSpan
@@ -55,6 +56,14 @@ object BindingAdapter {
         distance?.let {
             textView.text = String.format("%.1f km", distance)
             textView.background = null
+        }
+    }
+
+    @JvmStatic
+    @BindingAdapter(value = ["lat", "lng", "curLat", "curLng"])
+    fun inputDistance(textView: TextView, lat: Double?, lng: Double?, curLat: Double?, curLng: Double?) {
+        if(lat != null && lng != null && curLat != null && curLng != null) {
+            textView.text = DataHelper.convertDistance(lat, lng, curLat, curLng)
         }
     }
 

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/common/PagerAdapter.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/common/PagerAdapter.kt
@@ -1,5 +1,6 @@
 package com.sandy.seoul_matcheap.ui.common
 
+import android.location.Location
 import android.view.*
 import androidx.recyclerview.widget.*
 import androidx.recyclerview.widget.RecyclerView.OnScrollListener
@@ -18,13 +19,17 @@ import com.sandy.seoul_matcheap.util.constants.TYPE_NORMAL_SCROLL
  */
 
 typealias Adapter = RecyclerView.Adapter<out RecyclerView.ViewHolder>
-class PagerAdapter<T: Adapter>(private val t: T, private val size: Int = CATEGORY_SIZE) : RecyclerView.Adapter<PagerAdapter<T>.ItemPagerViewHolder>(){
+class PagerAdapter<T: Adapter>(
+    private val t: T,
+    private val size: Int = CATEGORY_SIZE,
+    private val location: Location? = null
+) : RecyclerView.Adapter<PagerAdapter<T>.ItemPagerViewHolder>(){
 
     val adapter = hashMapOf<Int, T>().also {
         repeat(size) { position ->
             it[position] = when(t) {
                 is StoreListAdapter -> StoreListAdapter()
-                else -> BookmarkListAdapter()
+                else -> BookmarkListAdapter(location!!)
             } as T
         }
     }.toMap()

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/home/HomeFragment.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/home/HomeFragment.kt
@@ -8,10 +8,12 @@ import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.fragment.app.activityViewModels
 import com.sandy.seoul_matcheap.BuildConfig
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.RecyclerView
 import com.sandy.seoul_matcheap.R
+import com.sandy.seoul_matcheap.data.store.dao.StoreItem
 import com.sandy.seoul_matcheap.databinding.FragmentHomeBinding
 import com.sandy.seoul_matcheap.ui.common.BaseFragment
 import com.sandy.seoul_matcheap.ui.LocationViewModel
@@ -26,7 +28,7 @@ import javax.inject.Named
 @AndroidEntryPoint
 class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
 
-    private val locationViewModel: LocationViewModel by viewModels()
+    private val locationViewModel: LocationViewModel by activityViewModels()
     private val homeViewModel : HomeViewModel by viewModels()
 
     override fun setupBinding(): FragmentHomeBinding = binding.apply {
@@ -36,26 +38,15 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
         viewModel = homeViewModel
     }
 
-    @Inject lateinit var locationManager: LocationManager
-    private var isLoaded = false
-    override fun downloadData() {
-        if(homeViewModel.getCurLoadingState() != ConnectState.NONE) return
-        updateLocation(locationViewModel, locationManager)
-        with(homeViewModel) {
-            updateSurroundingStoreList()
-            updateRandomStoreList()
-        }
-        isLoaded = true
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        checkVersionUpdate(BuildConfig.VERSION_NAME)
+        checkVersionUpdate()
         super.onViewCreated(view, savedInstanceState)
     }
 
     @Inject @Named(APP_PREFS_SETTINGS)
     lateinit var prefs: SharedPreferences
-    private fun checkVersionUpdate(currentVersion: String) {
+    private fun checkVersionUpdate() {
+        val currentVersion = BuildConfig.VERSION_NAME
         when(AppPrefsUtils.getSavedVersion(prefs)) {
             currentVersion -> return
             null -> AppPrefsUtils.saveCurrentVersion(prefs, currentVersion)
@@ -76,6 +67,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
             addOnItemClickListener()
         }
     }
+
     override fun RecyclerView.Adapter<out RecyclerView.ViewHolder>.addOnItemClickListener() {
         when(this) {
             is RegionSpinnerAdapter -> setOnItemClickListener{
@@ -88,7 +80,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     }
 
     override fun initView() = binding.run {
-        setSavedBackstackState()
+        checkSavedBackstackState()
 
         rvRegionSpinner.addAdapter(regionSpinnerAdapter)
         regionSpinnerView.setOnRegionSpinnerViewClickListener()
@@ -102,7 +94,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     }
 
     private var onBackstackCallback = false
-    private fun setSavedBackstackState() = binding.apply {
+    private fun checkSavedBackstackState() = binding.apply {
         if(!onBackstackCallback) {
             nestedScrollView.post {
                 nestedScrollView.scrollY = DEFAULT_POSITION
@@ -123,16 +115,14 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
         rvRegionSpinner.y = SPINNER_DEFAULT_POSION_Y
     }
 
-    // RegionButton을 클릭 했을 때, region spinner가 나타나야하며, 이 때 region spinner는 반드시 위치가 설정된 후 화면에 보여져야함
-    private fun View.setOnRegionButtonClickListener() {
-        setOnClickListener {
-            changeRegionSpinnerRecyclerViewPositionY()
-            showRegionSpinnerView()
-        }
+    // RegionButton을 클릭 했을 때, region spinner가 나타나야하며 이 때 region spinner는 반드시 위치가 설정된 후 화면에 보여져야함
+    private fun View.setOnRegionButtonClickListener() = setOnClickListener {
+        setRegionSpinnerPositionY()
+        showRegionSpinnerView()
     }
 
     private var SPINNER_DEFAULT_POSION_Y: Float = 0.0f
-    private fun changeRegionSpinnerRecyclerViewPositionY() = binding.rvRegionSpinner.apply {
+    private fun setRegionSpinnerPositionY() = binding.rvRegionSpinner.apply {
         // spinner의 default positionY를 측정하여 저장
         SPINNER_DEFAULT_POSION_Y = y
         y = SPINNER_DEFAULT_POSION_Y - binding.nestedScrollView.scrollY
@@ -145,6 +135,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
         rvRegionSpinner.scrollToPosition(DEFAULT_POSITION)
     }
 
+    @Inject lateinit var locationManager: LocationManager
     private var gpsButtonClick = false
     private fun ImageView.setOnGpsUpdateButtonClickListener() = setOnClickListener {
         gpsButtonClick = true
@@ -164,7 +155,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     override fun subscribeToObservers() {
         subscribeToLoadStateObserver()
         subscribeToLocationObserver()
-        subscribeToStoreDataObserver()
+        subscribeToSurroundingStoresObserver()
     }
 
     private fun subscribeToLoadStateObserver() {
@@ -172,6 +163,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
             handleLoadingState(it)
         }
     }
+
     private fun handleLoadingState(state: ConnectState) = when(state) {
         ConnectState.SUCCESS -> handleLoadSuccess()
         ConnectState.FAIL -> handleLoadFail()
@@ -184,10 +176,10 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
         showNetworkErrorToastMessage()
         binding.progressView.fail.visibility = View.VISIBLE
     }
-    private fun showNetworkErrorToastMessage() = if(isLoaded) {
+
+    private var isLoaded = false
+    private fun showNetworkErrorToastMessage() {
         showToastMessage(MESSAGE_NETWORK_ERROR)
-    } else {
-        isLoaded = true
     }
 
     private fun handleNotLoad() {
@@ -199,14 +191,29 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
 
     private fun subscribeToLocationObserver() = locationViewModel.run {
         location.observe(viewLifecycleOwner) {
-            updateForecast(it)
+            handleLocationInfo(it)
         }
         address.observe(viewLifecycleOwner) {
             handleAddress(it)
         }
     }
-    private fun updateForecast(location: Location?) = location?.let {
-        homeViewModel.updateForecast(it.latitude, it.longitude)
+
+    private fun handleLocationInfo(location: Location?) = location?.let {
+        with(homeViewModel) {
+            updateRandomStoreList()
+            updateForecast(it)
+            updateSurroundingStoreList(it)
+        }
+    }
+
+    private fun subscribeToSurroundingStoresObserver() {
+        homeViewModel.surroundingStores.observe(viewLifecycleOwner) {
+            handleSurroundStores(it)
+        }
+    }
+
+    private fun handleSurroundStores(stores: List<StoreItem>) {
+        surroundingStoreAdapter?.submitList(stores)
     }
 
     // 현재 주소를 알려주는 toast message는 반드시 gps update button가 호출 되었을 때만 생성 되어야 함
@@ -216,14 +223,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
         gpsButtonClick = false
     }
 
-    private fun subscribeToStoreDataObserver(){
-        homeViewModel.surroundingStores.observe(viewLifecycleOwner) {
-            surroundingStoreAdapter?.run { submitList(it) }
-        }
-    }
-
     fun navigateToStoreListForCategory(v: View, code: String) {
-
         v.changeScale()
         navigateToStoreList(code, TYPE_CATEGORY)
     }
@@ -243,7 +243,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     }
 
     override fun destroyGlobalVariables() {
-        locationViewModel.init()
         regionSpinnerAdapter = null
         surroundingStoreAdapter = null
         isLoaded = false

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/home/HomeViewModel.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/home/HomeViewModel.kt
@@ -1,16 +1,18 @@
 package com.sandy.seoul_matcheap.ui.home
 
+import android.location.Location
 import androidx.lifecycle.*
 import com.sandy.seoul_matcheap.data.forecast.Forecast
 import com.sandy.seoul_matcheap.data.forecast.ForecastRepository
 import com.sandy.seoul_matcheap.data.store.dao.RandomStore
-import com.sandy.seoul_matcheap.data.store.dao.SurroundingStore
+import com.sandy.seoul_matcheap.data.store.dao.StoreItem
 import com.sandy.seoul_matcheap.data.store.repository.StoreRepository
 import com.sandy.seoul_matcheap.util.constants.ConnectState
 import com.sandy.seoul_matcheap.util.constants.DEFAULT_
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
 import javax.inject.Inject
+import kotlin.math.ln
 
 /**
  * @author SANDY
@@ -25,14 +27,15 @@ class HomeViewModel @Inject constructor (
     private val forecastRepository: ForecastRepository
 ) : ViewModel() {
 
-    //!-- store
-    private val _surroundingStores = MutableLiveData<List<SurroundingStore>>()
-    val surroundingStores: LiveData<List<SurroundingStore>> = _surroundingStores
-    fun updateSurroundingStoreList() = viewModelScope.launch(Dispatchers.IO) {
-        val stores = storeRepository.downloadSurroundingStores()
+    //!-- surrounding stores
+    private val _surroundingStores = MutableLiveData<List<StoreItem>>()
+    val surroundingStores: LiveData<List<StoreItem>> = _surroundingStores
+    fun updateSurroundingStoreList(location: Location) = viewModelScope.launch(Dispatchers.IO) {
+        val stores = storeRepository.downloadSurroundingStores(location)
         _surroundingStores.postValue(stores)
     }
 
+    //!-- random stores
     private val _randomStore = MutableLiveData<List<RandomStore>>()
     val randomStore: LiveData<List<RandomStore>> = _randomStore
     fun updateRandomStoreList() = viewModelScope.launch(Dispatchers.IO) {
@@ -40,12 +43,12 @@ class HomeViewModel @Inject constructor (
         _randomStore.postValue(stores)
     }
 
+
     private val _loadingState = MutableLiveData(ConnectState.NONE)
     val loadingState : LiveData<ConnectState> = _loadingState
     fun setLoadingState(state: ConnectState) {
         _loadingState.postValue(state)
     }
-    fun getCurLoadingState() = _loadingState.value!!
 
 
     //!-- forecast
@@ -57,8 +60,8 @@ class HomeViewModel @Inject constructor (
     val sky : LiveData<String> = _sky
     private val _wind = MutableLiveData<String>()
     val wind : LiveData<String> = _wind
-    fun updateForecast(lat: Double, lng: Double) = viewModelScope.launch(Dispatchers.IO) {
-        val result = forecastRepository.downloadCurrentForecast(lat, lng)
+    fun updateForecast(location: Location) = viewModelScope.launch(Dispatchers.IO) {
+        val result = forecastRepository.downloadCurrentForecast(location.latitude, location.longitude)
         updateWeather(result)
     }
 

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/home/SurroundingStoreAdapter.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/home/SurroundingStoreAdapter.kt
@@ -2,7 +2,7 @@ package com.sandy.seoul_matcheap.ui.home
 
 import android.content.Context
 import com.sandy.seoul_matcheap.R
-import com.sandy.seoul_matcheap.data.store.dao.SurroundingStore
+import com.sandy.seoul_matcheap.data.store.dao.StoreItem
 import com.sandy.seoul_matcheap.databinding.ItemRvSurroundingBinding
 import com.sandy.seoul_matcheap.ui.common.BaseListAdapter
 import com.sandy.seoul_matcheap.util.constants.DEFAULT_POSITION
@@ -13,9 +13,9 @@ import com.sandy.seoul_matcheap.util.constants.DEFAULT_POSITION
  * @created 2023-04-07
  * @desc
  */
-class SurroundingStoreAdapter : BaseListAdapter<ItemRvSurroundingBinding, SurroundingStore>(R.layout.item_rv_surrounding) {
+class SurroundingStoreAdapter() : BaseListAdapter<ItemRvSurroundingBinding, StoreItem>(R.layout.item_rv_surrounding) {
 
-    override fun ItemRvSurroundingBinding.setBinding(item: SurroundingStore, position: Int) {
+    override fun ItemRvSurroundingBinding.setBinding(item: StoreItem, position: Int) {
         store = item
         root.apply {
             if(position == DEFAULT_POSITION) setPadding(48, 0, 0, 0)
@@ -24,7 +24,7 @@ class SurroundingStoreAdapter : BaseListAdapter<ItemRvSurroundingBinding, Surrou
     }
 
     override fun handlePreload(context: Context, preloadPosition: Int) {
-        val preloadUrl = (getItem(preloadPosition) as SurroundingStore).photo
+        val preloadUrl = (getItem(preloadPosition) as StoreItem).photo
         preload(context, preloadUrl)
     }
 

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/more/bookmark/BookmarkFragment.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/more/bookmark/BookmarkFragment.kt
@@ -2,15 +2,15 @@ package com.sandy.seoul_matcheap.ui.more.bookmark
 
 import android.os.Bundle
 import android.view.*
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
 import com.sandy.seoul_matcheap.R
 import com.sandy.seoul_matcheap.data.store.dao.BookmarkedStore
 import com.sandy.seoul_matcheap.databinding.FragmentBookmarkBinding
+import com.sandy.seoul_matcheap.ui.LocationViewModel
 import com.sandy.seoul_matcheap.ui.common.BaseFragment
 import com.sandy.seoul_matcheap.ui.common.PagerAdapter
-import com.sandy.seoul_matcheap.util.*
 import com.sandy.seoul_matcheap.util.constants.CATEGORY_SIZE
 import com.sandy.seoul_matcheap.util.constants.DEFAULT_POSITION
 import com.sandy.seoul_matcheap.util.constants.TYPE_NORMAL_SCROLL
@@ -19,7 +19,8 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class BookmarkFragment : BaseFragment<FragmentBookmarkBinding>(R.layout.fragment_bookmark) {
 
-    private val bookmarkViewModel : BookmarkViewModel by viewModels()
+    private val bookmarkViewModel: BookmarkViewModel by viewModels()
+    private val locationViewModel: LocationViewModel by activityViewModels()
 
     override fun setupBinding(): FragmentBookmarkBinding {
         return binding.apply {
@@ -35,7 +36,8 @@ class BookmarkFragment : BaseFragment<FragmentBookmarkBinding>(R.layout.fragment
 
     private var pagerAdapter: PagerAdapter<BookmarkListAdapter>? = null
     override fun initGlobalVariables() {
-        pagerAdapter = PagerAdapter(BookmarkListAdapter())
+        val location = locationViewModel.getCurLocation()
+        pagerAdapter = PagerAdapter(BookmarkListAdapter(location), location = location)
     }
 
     override fun initView() = binding.run {

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/more/bookmark/BookmarkListAdapter.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/more/bookmark/BookmarkListAdapter.kt
@@ -1,6 +1,7 @@
 package com.sandy.seoul_matcheap.ui.more.bookmark
 
 import android.content.Context
+import android.location.Location
 import com.sandy.seoul_matcheap.R
 import com.sandy.seoul_matcheap.data.store.dao.BookmarkedStore
 import com.sandy.seoul_matcheap.databinding.ItemRvBookmarkBinding
@@ -14,7 +15,7 @@ import com.sandy.seoul_matcheap.util.constants.PAGE_DISTANCE
  * @created 2023-04-09
  * @desc
  */
-class BookmarkListAdapter : BaseListAdapter<ItemRvBookmarkBinding, BookmarkedStore>(R.layout.item_rv_bookmark) {
+class BookmarkListAdapter(private val location: Location) : BaseListAdapter<ItemRvBookmarkBinding, BookmarkedStore>(R.layout.item_rv_bookmark) {
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         super.onBindViewHolder(holder, position)
@@ -22,6 +23,7 @@ class BookmarkListAdapter : BaseListAdapter<ItemRvBookmarkBinding, BookmarkedSto
     }
 
     override fun ItemRvBookmarkBinding.setBinding(item: BookmarkedStore, position: Int) {
+        location = this@BookmarkListAdapter.location
         bookmarkedStore = item
         item.menu?.let { menus ->
             rvMenu.adapter = StoreMenuAdapter().also {

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/search/SearchFragment.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/search/SearchFragment.kt
@@ -3,7 +3,6 @@ package com.sandy.seoul_matcheap.ui.search
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import com.sandy.seoul_matcheap.R
 import com.sandy.seoul_matcheap.databinding.FragmentSearchBinding

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/search/SearchResultFragment.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/search/SearchResultFragment.kt
@@ -12,7 +12,7 @@ import androidx.paging.PagingData
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.textfield.*
 import com.sandy.seoul_matcheap.R
-import com.sandy.seoul_matcheap.data.store.dao.StoreListItem
+import com.sandy.seoul_matcheap.data.store.dao.StoreItem
 import com.sandy.seoul_matcheap.databinding.FragmentSearchResultBinding
 import com.sandy.seoul_matcheap.ui.common.BaseFragment
 import com.sandy.seoul_matcheap.ui.LocationViewModel
@@ -40,15 +40,14 @@ class SearchResultFragment : BaseFragment<FragmentSearchResultBinding>(R.layout.
     @Inject lateinit var locationManager: LocationManager
     override fun downloadData() {
         requestSearch(args.searchWord)
-        updateLocation(locationViewModel, locationManager)
     }
 
     private fun requestSearch(param: String) {
-        searchViewModel.apply {
-            input.value = param
-            requestSearch(param)
-        }
         showProgressView(binding.progressView)
+        searchViewModel.run {
+            input.value = param
+            requestSearch(param, locationViewModel.getCurLocation())
+        }
     }
 
     private var autoCompleteListAdapter : AutoCompleteListAdapter? = null
@@ -134,7 +133,7 @@ class SearchResultFragment : BaseFragment<FragmentSearchResultBinding>(R.layout.
         }
     }
 
-    private fun updateStoreList(result: PagingData<StoreListItem>) {
+    private fun updateStoreList(result: PagingData<StoreItem>) {
         storeListAdapter?.submitData(lifecycle, result)
         binding.rvResultList.scrollToPosition(DEFAULT_POSITION)
     }

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/search/SearchViewModel.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/search/SearchViewModel.kt
@@ -1,9 +1,10 @@
 package com.sandy.seoul_matcheap.ui.search
 
+import android.location.Location
 import androidx.lifecycle.*
 import androidx.paging.*
 import com.sandy.seoul_matcheap.data.store.dao.AutoComplete
-import com.sandy.seoul_matcheap.data.store.dao.StoreListItem
+import com.sandy.seoul_matcheap.data.store.dao.StoreItem
 import com.sandy.seoul_matcheap.data.store.entity.SearchHistory
 import com.sandy.seoul_matcheap.data.store.repository.SearchRepository
 import com.sandy.seoul_matcheap.util.helper.DataHelper
@@ -73,16 +74,15 @@ class SearchViewModel @Inject constructor(private val searchRepository: SearchRe
     }
 
     //!-- search
-    private val _searchResultList = MutableLiveData<PagingSource<Int, StoreListItem>>()
+    private val _searchResultList = MutableLiveData<PagingSource<Int, StoreItem>>()
     val searchResultList = _searchResultList.switchMap {
         Pager(PagingConfig(pageSize = 10, prefetchDistance = 1, maxSize = 50)) {
             it
         }.liveData.cachedIn(viewModelScope)
     }
-    fun requestSearch(param: String) = viewModelScope.launch(Dispatchers.IO) {
-        _searchResultList.postValue(
-            searchRepository.requestSearchStore(param)
-        )
+    fun requestSearch(param: String, location: Location) = viewModelScope.launch(Dispatchers.IO) {
+        val searchResult = searchRepository.requestSearchStore(param, location.latitude, location.longitude)
+        _searchResultList.postValue(searchResult)
     }
 
 }

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/splash/LoadViewModel.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/splash/LoadViewModel.kt
@@ -61,12 +61,7 @@ class LoadViewModel @Inject constructor(
             val token = it.split("\t")
             val lat = token[13].trim().toDouble()
             val lng = token[14].trim().toDouble()
-            val distance = DataHelper.calculateDistance(
-                curLat = location.latitude,
-                curLng = location.longitude,
-                lat = lat,
-                lng = lng
-            )
+            val distance = 0.0
             StoreInfo(
                 id = "0000" + token[0].trim(),
                 code = token[1].trim(),

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/splash/SplashFragment.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/splash/SplashFragment.kt
@@ -1,15 +1,14 @@
 package com.sandy.seoul_matcheap.ui.splash
 
 import android.Manifest.permission.*
-import android.app.Activity
 import android.content.Context
 import android.content.SharedPreferences
 import android.location.Location
 import android.location.LocationManager
-import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -22,6 +21,7 @@ import com.google.firebase.remoteconfig.ktx.remoteConfig
 import com.google.firebase.remoteconfig.ktx.remoteConfigSettings
 import com.sandy.seoul_matcheap.BuildConfig
 import com.sandy.seoul_matcheap.R
+import com.sandy.seoul_matcheap.data.store.StoreDatabase
 import com.sandy.seoul_matcheap.databinding.FragmentSplashBinding
 import com.sandy.seoul_matcheap.ui.LocationViewModel
 import com.sandy.seoul_matcheap.ui.common.BaseFragment
@@ -38,16 +38,22 @@ import javax.inject.Named
 
 @AndroidEntryPoint
 class SplashFragment : BaseFragment<FragmentSplashBinding>(R.layout.fragment_splash) {
-
+    
     override fun setupBinding() = binding
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         fetchRemoteConfig()
     }
+
     @Inject @Named(APP_PREFS_SETTINGS)
     lateinit var prefs : SharedPreferences
-    private fun fetchRemoteConfig() = AppPrefsUtils.getSavedVersion(prefs)?.let { _ ->
+    private fun fetchRemoteConfig() = when {
+        AppPrefsUtils.getSavedAppVersion(prefs) != null -> receiveRemoteConfig()
+        else -> requestPermissions()
+    }
+
+    private fun receiveRemoteConfig() {
         val configSettings = remoteConfigSettings { }
         Firebase.remoteConfig.run {
             setConfigSettingsAsync(configSettings)
@@ -58,31 +64,34 @@ class SplashFragment : BaseFragment<FragmentSplashBinding>(R.layout.fragment_spl
             })
             addOnFetchCompleteListener(this)
         }
-    } ?: requestPermissions()
+    }
 
     private fun FirebaseRemoteConfig.addOnFetchCompleteListener(remoteConfig: FirebaseRemoteConfig) {
         fetchAndActivate().addOnCompleteListener(requireActivity()) {
-            checkVersion(it.isSuccessful, remoteConfig)
+            val newVersion = remoteConfig.getString(APP_VERSION)
+            checkAppVersion(checkable = it.isSuccessful, versionCheck = BuildConfig.VERSION_NAME == newVersion)
         }
     }
 
-    private fun checkVersion(isCheckable: Boolean, remoteConfig: FirebaseRemoteConfig) = when {
-        isCheckable -> showAppUpdateNoticeDialog(BuildConfig.VERSION_NAME != remoteConfig.getString(APP_VERSION))
-        else -> showToastMessage(MESSAGE_NETWORK_ERROR).also { requestPermissions() }
-    }
-    private fun showAppUpdateNoticeDialog(show: Boolean) = when {
-        show -> createAppUpdateNoticeDialogBuilder().show()
-        else -> requestPermissions()
-    }
-    private fun createAppUpdateNoticeDialogBuilder() = MaterialAlertDialogBuilder(requireContext())
-        .setTitle(APP_NAME)
-        .setMessage(MESSAGE_NEW_VERSION_UPDATE)
-        .setCancelable(false)
-        .setNegativeButton(BUTTON_TITLE_UPDATE) { _, _ ->
-            navigateToBrowser(MARKET_URI + requireContext().packageName)
-            setOnBackPressedListener()
+    private fun checkAppVersion(checkable: Boolean, versionCheck: Boolean) = when {
+        checkable && !versionCheck -> showAppUpdateNoticeDialog()
+        else -> requestPermissions().also {
+            if(!checkable) showToastMessage(MESSAGE_NETWORK_ERROR)
         }
-        .setPositiveButton(BUTTON_TITLE_CONFIRM) { _, _ -> requestPermissions() }
+    }
+
+    private fun showAppUpdateNoticeDialog() {
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(APP_NAME)
+            .setMessage(MESSAGE_NEW_VERSION_UPDATE)
+            .setCancelable(false)
+            .setNegativeButton(BUTTON_TITLE_UPDATE) { _, _ ->
+                navigateToBrowser(MARKET_URI + requireContext().packageName)
+                setOnBackPressedListener()
+            }
+            .setPositiveButton(BUTTON_TITLE_CONFIRM) { _, _ -> requestPermissions() }
+            .show()
+    }
 
     private fun requestPermissions() {
         val permissions = arrayOf(
@@ -141,11 +150,11 @@ class SplashFragment : BaseFragment<FragmentSplashBinding>(R.layout.fragment_spl
     }
 
     @Inject lateinit var locationManager : LocationManager
-    private val locationViewModel: LocationViewModel by viewModels()
+    private val locationViewModel: LocationViewModel by activityViewModels()
     private fun requestLocationUpdate() {
-        binding.tvLoading.visibility = View.VISIBLE
         getGpsProviderState(locationManager)
         locationViewModel.updateLocation()
+        binding.tvLoading.visibility = View.VISIBLE
     }
 
     private fun hasNotLocationPermission() {
@@ -169,50 +178,65 @@ class SplashFragment : BaseFragment<FragmentSplashBinding>(R.layout.fragment_spl
 
     private fun subscribeToLocationObserver() {
         locationViewModel.location.observe(viewLifecycleOwner) {
-            it?.let {
-                locationViewModel.stopLocation()
-                fetchDatabase(it)
-            }
+            handleLocationAndCheckDB(it)
         }
     }
 
-    // upgrade database using location information
-    private val loadViewModel: LoadViewModel by viewModels()
-    private fun fetchDatabase(location: Location) {
-        val dataSaveState = AppPrefsUtils.getDatabaseState(prefs) == APP_DATABASE_STATE
+    private fun handleLocationAndCheckDB(location: Location?) = location?.let {
+        locationViewModel.stopLocation()
+        checkDatabaseVersion()
+    }
 
-        val storeData = DataHelper.downloadStoreData(requireContext())
-        val polygonData = if(dataSaveState) null else DataHelper.downloadPolygonData(requireContext())
-        loadViewModel.updateDatabase(location, storeData, polygonData)
+    // upgrade database using location information
+    @Inject lateinit var db: StoreDatabase
+    private val loadViewModel: LoadViewModel by viewModels()
+    private fun checkDatabaseVersion() {
+        val latestDatabaseVersion = db.openHelper.readableDatabase.version.toString()
+        val savedDatabaseVersion = AppPrefsUtils.getSavedDatabaseVersion(prefs)
+        when (latestDatabaseVersion) {
+            savedDatabaseVersion -> loadViewModel.setLoadState(true)
+            else -> fetchDatabase(requireContext())
+        }
+    }
+
+    private fun fetchDatabase(context: Context) {
+        val storeData = DataHelper.downloadStoreData(context)
+        val polygonData = DataHelper.downloadPolygonData(context)
+        loadViewModel.updateDatabase(storeData, polygonData)
     }
 
     private fun subscribeToLoadViewModelObserver() {
         loadViewModel.dataLoadSate.observe(viewLifecycleOwner) {
-            if(it) navigateToHome()
+            handleLoadState(it)
         }
     }
 
-    private fun navigateToHome() {
-        findNavController().navigate(getDestination(HOME_), null, getPopUpNavOptions())
+    private fun handleLoadState(isLoadEnd: Boolean) {
+        if(isLoadEnd) {
+            saveDatabaseVersion()
+            navigateToDestination()
+        }
     }
 
-    override fun setOnBackPressedListener() {
-        requireActivity().finishAffinity()
+    private fun saveDatabaseVersion() {
+        val latestDatabaseVersion = db.openHelper.readableDatabase.version.toString()
+        AppPrefsUtils.saveLatestDatabaseVersion(prefs, latestDatabaseVersion)
     }
 
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        val intent = (context as Activity).intent
-        handleDeepLink(intent.data)
+    private fun navigateToDestination() {
+        val uri = requireActivity().intent.data
+        findNavController().navigate(getDestination(uri?.path), null, getPopUpNavOptions())
     }
-    private fun handleDeepLink(data: Uri?) = data?.path?.let {
-        findNavController().navigate(getDestination(it), null, getPopUpNavOptions())
-    }
+
     private fun getDestination(path: String?) = when(path) {
         SEARCH_ -> R.id.action_splashFragment_to_searchFragment
         MAP_ -> R.id.action_splashFragment_to_mapFragment
         BOOKMARK_ -> R.id.action_splashFragment_to_bookMarkFragment
         else -> R.id.action_splashFragment_to_homeFragment
+    }
+
+    override fun setOnBackPressedListener() {
+        requireActivity().finishAndRemoveTask()
     }
 
     companion object {

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/store/StoreDetailsActivity.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/store/StoreDetailsActivity.kt
@@ -283,14 +283,12 @@ class StoreDetailsActivity : AppCompatActivity() {
             val item = StoreMapItem(
                 id = id,
                 code = code,
-                codeName = codeName,
                 gu = gu,
                 name = name,
                 address = address,
                 photo = photo,
                 lat = lat,
                 lng = lng,
-                distance = distance,
                 bookmarked = binding.btnBookmark.isSelected
             )
             val returnIntent = Intent().apply {

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/store/StoreListAdapter.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/store/StoreListAdapter.kt
@@ -5,7 +5,7 @@ import android.view.*
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import com.sandy.seoul_matcheap.data.store.dao.StoreListItem
+import com.sandy.seoul_matcheap.data.store.dao.StoreItem
 import com.sandy.seoul_matcheap.databinding.ItemRvStoreBinding
 import com.sandy.seoul_matcheap.util.constants.PAGE_DISTANCE
 import com.sandy.seoul_matcheap.util.module.GlideApp
@@ -16,7 +16,7 @@ import com.sandy.seoul_matcheap.util.module.GlideApp
  * @created 2023-03-06
  * @desc
  */
-class StoreListAdapter : PagingDataAdapter<StoreListItem, StoreListAdapter.ItemRvStoreViewHolder>(DIFF_UTIL) {
+class StoreListAdapter : PagingDataAdapter<StoreItem, StoreListAdapter.ItemRvStoreViewHolder>(DIFF_UTIL) {
 
     inner class ItemRvStoreViewHolder(val binding: ItemRvStoreBinding) : RecyclerView.ViewHolder(binding.root)
 
@@ -57,9 +57,9 @@ class StoreListAdapter : PagingDataAdapter<StoreListItem, StoreListAdapter.ItemR
     }
 
     companion object {
-        val DIFF_UTIL = object : DiffUtil.ItemCallback<StoreListItem>() {
-            override fun areItemsTheSame(oldItem: StoreListItem, newItem: StoreListItem)= oldItem.id == newItem.id
-            override fun areContentsTheSame(oldItem: StoreListItem, newItem: StoreListItem) = oldItem == newItem
+        val DIFF_UTIL = object : DiffUtil.ItemCallback<StoreItem>() {
+            override fun areItemsTheSame(oldItem: StoreItem, newItem: StoreItem)= oldItem.id == newItem.id
+            override fun areContentsTheSame(oldItem: StoreItem, newItem: StoreItem) = oldItem == newItem
         }
     }
 

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/util/helper/AppPrefsUtils.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/util/helper/AppPrefsUtils.kt
@@ -11,13 +11,13 @@ import com.sandy.seoul_matcheap.util.constants.*
  */
 object AppPrefsUtils {
 
-    fun setDatabaseState(prefs: SharedPreferences)  = prefs.edit()
-        .putString(APP_DATABASE_STATE, APP_DATABASE_STATE)
+    fun saveLatestDatabaseVersion(prefs: SharedPreferences, version: String)  = prefs.edit()
+        .putString(APP_DATABASE_STATE, version)
         .apply()
-    fun getDatabaseState(prefs: SharedPreferences) = prefs.getString(APP_DATABASE_STATE, null)
+    fun getSavedDatabaseVersion(prefs: SharedPreferences) = prefs.getString(APP_DATABASE_STATE, null)
 
-    fun getSavedVersion(prefs: SharedPreferences) = prefs.getString(APP_VERSION, null)
-    fun saveCurrentVersion(prefs: SharedPreferences, version: String) = prefs.edit()
+    fun getSavedAppVersion(prefs: SharedPreferences) = prefs.getString(APP_VERSION, null)
+    fun saveLatestAppVersion(prefs: SharedPreferences, version: String) = prefs.edit()
         .putString(APP_VERSION, version)
         .apply()
 

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/util/helper/DataHelper.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/util/helper/DataHelper.kt
@@ -1,6 +1,7 @@
 package com.sandy.seoul_matcheap.util.helper
 
 import android.content.Context
+import android.location.Location
 import java.text.SimpleDateFormat
 import java.time.Duration
 import java.time.LocalDate
@@ -29,8 +30,7 @@ object DataHelper {
         .bufferedReader()
         .readLines()
 
-    private val r = 6372.8 * 1000
-    fun calculateDistance(curLat: Double, curLng: Double, lat: Double, lng : Double) : Double {
+    fun convertDistance(lat: Double, lng : Double, curLat: Double, curLng: Double) : String {
         val a = 2 * asin(
             sqrt(
                 sin(Math.toRadians(lat - curLat) / 2).pow(2.0)
@@ -39,7 +39,7 @@ object DataHelper {
                         * cos(Math.toRadians(lat))
             )
         )
-        return r * a / 1000
+        return String.format("%.1f km", 6372.8 * a)
     }
 
     private val timeFormat = SimpleDateFormat("yyyyMMdd-HHmm")

--- a/Matcheap/app/src/main/res/layout/fragment_home.xml
+++ b/Matcheap/app/src/main/res/layout/fragment_home.xml
@@ -275,9 +275,10 @@
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toBottomOf="@+id/textView53"
-                            bind:fragment="@{fragment}"
                             bind:store1="@{viewModel.randomStore[0]}"
-                            bind:store2="@{viewModel.randomStore[1]}" />
+                            bind:store2="@{viewModel.randomStore[1]}"
+                            bind:fragment="@{fragment}"
+                            bind:location="@{location.location}"/>
 
                     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/Matcheap/app/src/main/res/layout/item_home_random.xml
+++ b/Matcheap/app/src/main/res/layout/item_home_random.xml
@@ -94,7 +94,7 @@
                     android:id="@+id/textView56"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@{store1.codeName}"
+                    Code="@{store1.code}"
                     android:textColor="@color/matcheap_gray"
                     android:textSize="10sp"
                     android:textStyle="bold" />
@@ -228,7 +228,7 @@
                     android:id="@+id/textView66"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@{store2.codeName}"
+                    Code="@{store2.code}"
                     android:textColor="@color/matcheap_gray"
                     android:textSize="10sp"
                     android:textStyle="bold" />

--- a/Matcheap/app/src/main/res/layout/item_home_random.xml
+++ b/Matcheap/app/src/main/res/layout/item_home_random.xml
@@ -13,6 +13,9 @@
         <variable
             name="fragment"
             type="com.sandy.seoul_matcheap.ui.home.HomeFragment" />
+        <variable
+            name="location"
+            type="android.location.Location" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -46,7 +49,6 @@
 
             <TextView
                 android:id="@+id/textView37"
-                Distance="@{store1.distance}"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="bottom|end"
@@ -58,7 +60,11 @@
                 android:shadowDx="1"
                 android:shadowDy="1"
                 android:shadowRadius="5"
-                android:textSize="10sp" />
+                android:textSize="10sp"
+                app:lat="@{store1.lat}"
+                app:lng="@{store1.lng}"
+                app:curLat="@{location.latitude}"
+                app:curLng="@{location.longitude}" />
         </androidx.cardview.widget.CardView>
 
         <androidx.cardview.widget.CardView
@@ -176,7 +182,6 @@
 
             <TextView
                 android:id="@+id/textView67"
-                Distance="@{store2.distance}"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="bottom|end"
@@ -188,7 +193,11 @@
                 android:shadowDx="1"
                 android:shadowDy="1"
                 android:shadowRadius="5"
-                android:textSize="10sp" />
+                android:textSize="10sp"
+                app:lat="@{store1.lat}"
+                app:lng="@{store1.lng}"
+                app:curLat="@{location.latitude}"
+                app:curLng="@{location.longitude}" />
         </androidx.cardview.widget.CardView>
 
         <androidx.cardview.widget.CardView

--- a/Matcheap/app/src/main/res/layout/item_rv_bookmark.xml
+++ b/Matcheap/app/src/main/res/layout/item_rv_bookmark.xml
@@ -66,7 +66,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
-            android:text="@{bookmarkedStore.store.codeName}"
+            Code="@{bookmarkedStore.store.code}"
             android:textColor="@color/matcheap_lightgray"
             android:textSize="12sp"
             app:layout_constraintStart_toEndOf="@+id/cardView"

--- a/Matcheap/app/src/main/res/layout/item_rv_bookmark.xml
+++ b/Matcheap/app/src/main/res/layout/item_rv_bookmark.xml
@@ -7,6 +7,9 @@
         <variable
             name="bookmarkedStore"
             type="com.sandy.seoul_matcheap.data.store.dao.BookmarkedStore" />
+        <variable
+            name="location"
+            type="android.location.Location" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -43,7 +46,6 @@
 
             <TextView
                 android:id="@+id/textView37"
-                Distance="@{bookmarkedStore.store.distance}"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="bottom|start|top|end"
@@ -52,6 +54,10 @@
                 android:background="#4D000000"
                 android:textColor="@color/white"
                 android:textSize="10sp"
+                app:lat="@{bookmarkedStore.store.lat}"
+                app:lng="@{bookmarkedStore.store.lng}"
+                app:curLat="@{location.latitude}"
+                app:curLng="@{location.longitude}"
                 tools:text="1.5 km" />
         </androidx.cardview.widget.CardView>
 

--- a/Matcheap/app/src/main/res/layout/item_rv_store.xml
+++ b/Matcheap/app/src/main/res/layout/item_rv_store.xml
@@ -4,10 +4,9 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
         <variable
             name="store"
-            type="com.sandy.seoul_matcheap.data.store.dao.StoreListItem" />
+            type="com.sandy.seoul_matcheap.data.store.dao.StoreItem" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -43,6 +42,7 @@
                 android:background="@drawable/bg_item" />
 
             <TextView
+                Code="@{store.code}"
                 android:id="@+id/textView18"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -53,7 +53,6 @@
                 android:paddingStart="8dp"
                 android:paddingVertical="2dp"
                 android:paddingEnd="4dp"
-                android:text="@{store.codeName}"
                 android:textColor="@color/white"
                 android:textSize="12sp"
                 tools:text="한식" />
@@ -103,13 +102,16 @@
 
         <TextView
             android:id="@+id/textView7"
-            Distance="@{store.distance}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="20dp"
             android:layout_marginBottom="8dp"
             android:textColor="@color/matcheap_lightgray"
             android:textSize="12sp"
+            app:lat="@{store.lat}"
+            app:lng="@{store.lng}"
+            app:curLat="@{store.curLat}"
+            app:curLng="@{store.curLng}"
             app:layout_constraintBottom_toTopOf="@+id/view3"
             app:layout_constraintEnd_toEndOf="parent" />
 

--- a/Matcheap/app/src/main/res/layout/item_rv_surrounding.xml
+++ b/Matcheap/app/src/main/res/layout/item_rv_surrounding.xml
@@ -6,7 +6,7 @@
     <data>
         <variable
             name="store"
-            type="com.sandy.seoul_matcheap.data.store.dao.SurroundingStore" />
+            type="com.sandy.seoul_matcheap.data.store.dao.StoreItem" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -102,7 +102,6 @@
 
                 <TextView
                     android:id="@+id/distance"
-                    Distance="@{store.distance}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="start|top"
@@ -120,6 +119,10 @@
                     android:textStyle="bold"
                     app:layout_constraintStart_toStartOf="@+id/photo"
                     app:layout_constraintTop_toTopOf="@+id/photo"
+                    app:lat="@{store.lat}"
+                    app:lng="@{store.lng}"
+                    app:curLat="@{store.curLat}"
+                    app:curLng="@{store.curLng}"
                     tools:text="1.2 km" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
StoreDao 거리 가져오는 쿼리 변경 : Distance를 직접 계산하는 쿼리를 사용한 이유

1. 거리순 정렬이 필요함
2. 페이징 처리가 필요함
3. 성능 저하를 고려하기엔 직접 계산하는 쿼리를 사용해도 현재 데이터양을 처리하는데는 큰 영향이 없을 것

1의 경우 room db에서 데이터를 가져온 후 거리 계산하는 식으로 sort함수를 만들어 후처리(가공)해서 정렬 가능
그러나 2의 경우 후처리하는 코드로 paging source까지 추가로 만들어서 가공해야하는 번거로움이 생겨버림

가져온 데이터를 12의 후처리를 하기 위해 또 한번의 전체 반복문을 거치게 되고, 그 이후 ui에 뿌리는 과정에서 또 한번의 반복문이 발생하게 되어 오히려 더 번거롭고 안 좋은 선택이라 판단함
