### PR TITLE
fix: 북마크 업데이트 관련 버그

### DIFF
--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/map/MapViewModel.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/map/MapViewModel.kt
@@ -190,8 +190,29 @@ class MapViewModel @Inject constructor(
         createPolygonOverlays()
     }
 
+    private fun clearMarkers() {
+        viewModelScope.launch {
+            storeMarkers.value?.forEach { (u, i) ->
+                u.map = null
+                i.map = null
+            }
+        }
+        viewModelScope.launch {
+            polygonOverlays.value?.forEach { (_, polygonOverlay) ->
+                polygonOverlay.map = null
+            }
+        }
+        viewModelScope.launch {
+            countMarkers.value?.forEach { (_, marker) ->
+                marker.map = null
+            }
+        }
+        rangeCircleOverlay.value?.map = null
+    }
+
     public override fun onCleared() {
         initData()
+        clearMarkers()
         super.onCleared()
     }
 

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/more/bookmark/BookmarkViewModel.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/more/bookmark/BookmarkViewModel.kt
@@ -5,6 +5,7 @@ import com.sandy.seoul_matcheap.data.store.dao.BookmarkedStore
 import com.sandy.seoul_matcheap.data.store.repository.BookmarkRepository
 import com.sandy.seoul_matcheap.util.constants.ConnectState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -36,7 +37,7 @@ class BookmarkViewModel @Inject constructor(private val bookmarkRepository: Book
         this.code.value = code
     }
 
-    fun updateBookmark(id: String, code: String, bookmarked: Boolean) = viewModelScope.launch(Dispatchers.IO) {
+    fun updateBookmark(id: String, code: String, bookmarked: Boolean) = CoroutineScope(Dispatchers.IO).launch {
         setLoadingState(ConnectState.ING)
         when {
             bookmarked -> addBookmark(id, code)

--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/util/helper/MapUtils.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/util/helper/MapUtils.kt
@@ -3,7 +3,6 @@ package com.sandy.seoul_matcheap.util.helper
 import android.content.Context
 import android.graphics.Color
 import android.graphics.PointF
-import android.view.LayoutInflater
 import android.view.View
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraAnimation
@@ -52,11 +51,10 @@ class MapUtils @Inject constructor(context: Context) {
         minZoom = if(hasInfoWindow) MAP_INFO_MAX_ZOOM else MAP_INFO_MIN_ZOOM
     }
 
-    private val markerBinding by lazy { ItemMapMarkerBinding.inflate(LayoutInflater.from(context)) }
-    fun getAdapter(store: StoreMapItem, clicked: Boolean, hasInfoWindow: Boolean) = object : InfoWindow.ViewAdapter() {
-        override fun getView(p0: InfoWindow): View = getStoreMarkerView(store, clicked, hasInfoWindow)
+    fun getAdapter(store: StoreMapItem, clicked: Boolean, hasInfoWindow: Boolean, binding: ItemMapMarkerBinding) = object : InfoWindow.ViewAdapter() {
+        override fun getView(p0: InfoWindow): View = getStoreMarkerView(store, clicked, hasInfoWindow, binding)
     }
-    private fun getStoreMarkerView(store: StoreMapItem, clicked: Boolean, hasInfoWindow: Boolean) = markerBinding.run {
+    private fun getStoreMarkerView(store: StoreMapItem, clicked: Boolean, hasInfoWindow: Boolean, binding: ItemMapMarkerBinding) = binding.run {
         with(bgInfo) {
             visibility = if(hasInfoWindow) View.VISIBLE else View.GONE
             backgroundTintList = if(clicked) Resource.matCheapBlue else Resource.matCheapWhite

--- a/Matcheap/app/src/main/res/layout/activity_store_details.xml
+++ b/Matcheap/app/src/main/res/layout/activity_store_details.xml
@@ -496,7 +496,7 @@
             android:layout_marginEnd="8dp"
             android:src="@drawable/bookmark_selector"
             Bookmark="@{storeDetails.bookmark.bookmarked}"
-            android:onClick="@{(v)->activity.updateBookmarkState(v, storeDetails.store)}"
+            android:onClick="@{(v)->activity.updateBookmarkState(v)}"
             app:layout_constraintBottom_toBottomOf="@+id/toolbar_area_before"
             app:layout_constraintEnd_toStartOf="@+id/btn_share"
             app:layout_constraintTop_toTopOf="@+id/guideline2" />

--- a/Matcheap/app/src/main/res/layout/item_map_store.xml
+++ b/Matcheap/app/src/main/res/layout/item_map_store.xml
@@ -169,7 +169,7 @@
             android:background="@drawable/ic_category"
             android:backgroundTint="@color/check_selector_color"
             android:checked="@{store.bookmarked}"
-            android:onCheckedChanged="@{(v, checked)->fragment.updateBookmarkState(store, checked)}"
+            android:onClick="@{()->fragment.checkNetworkConnect()}"
             android:gravity="center|top"
             android:paddingTop="4dp"
             android:stateListAnimator="@null"


### PR DESCRIPTION
1. 북마크 버그 현상 :
토글버튼을 반복 이용해 북마크 요청시 네트워크 요청을 무수히 발생시켜 북마크에 메뉴가 두번 저장되거나 ANR 발생
-> 뷰가 onStop될 때 DB에 반영되도록 수정(네트워크 요청 1번)

2. 맵 버그 현상 :
mapFragment가 종료되어도 지도 위 기존 마커 객체가 남아 mapFragment를 로드했을 때 마커가 두번 생성되는 경우 발생
-> 뷰모델 onCleared()함수에 지도 위 마커들을 제거하도록 추가
