### PR TITLE
hotfix: 플레이 스토어 앱 업데이트 링크 수정

### DIFF
--- a/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/splash/SplashFragment.kt
+++ b/Matcheap/app/src/main/java/com/sandy/seoul_matcheap/ui/splash/SplashFragment.kt
@@ -88,7 +88,7 @@ class SplashFragment : BaseFragment<FragmentSplashBinding>(R.layout.fragment_spl
             .setMessage(MESSAGE_NEW_VERSION_UPDATE)
             .setCancelable(false)
             .setNegativeButton(BUTTON_TITLE_UPDATE) { _, _ ->
-                navigateToBrowser(MARKET_URI + requireContext().packageName)
+                navigateToBrowser(MARKET_URL + requireContext().packageName)
                 setOnBackPressedListener()
             }
             .setPositiveButton(BUTTON_TITLE_CONFIRM) { _, _ -> requestPermissions() }
@@ -251,7 +251,7 @@ class SplashFragment : BaseFragment<FragmentSplashBinding>(R.layout.fragment_spl
     companion object {
         private const val BUTTON_TITLE_UPDATE = "업데이트"
         private const val BUTTON_TITLE_CONFIRM = "확인"
-        private const val MARKET_URI = "market://details?id="
+        private const val MARKET_URL = "https://play.google.com/store/apps/details?id="
     }
 
 }


### PR DESCRIPTION
### 앱 업데이트를 위해 플레이 스토어로 연결되는 URI에서 버그가 발생

해결) 플레이 스토어 앱 업데이트 화면으로 가는 URL로 수정